### PR TITLE
add source jar generation and gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.project
+.classpath
+.settings
+*.ipr
+.idea
+*.iws
+*.iml
+*~
+.DS_Store
+/target
+test-output
+.externalToolBuilders
+coverage-error.log

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,20 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
I added gitignore file for ignoring standard Eclipse and InteliJ Idea project files from git.

I also added plugin for generation of source jars, so the sources are available during debugging of application using sdk jar.

Signed-off-by: Matus Zamborsky <zamborsky@gmail.com>