### PR TITLE
fix Curve name

### DIFF
--- a/src/main/java/com/github/ontio/crypto/Curve.java
+++ b/src/main/java/com/github/ontio/crypto/Curve.java
@@ -8,7 +8,7 @@ public enum Curve {
     P224(1, "P-224"),
     P256(2, "P-256"),
     P384(3, "P-384"),
-    P512(4, "P-512"),
+    P512(4, "P-521"),
     SM2P256V1(20, "sm2p256v1");
 
     private int label;


### PR DESCRIPTION
The correct name for the curve is P-521 and not P-512. Because of this problem, method Curve.valueOf will fail for P-512 and also for sm2p256v1 (because of the iteration in the method).